### PR TITLE
Allow opening editors from search and other search UI improvements

### DIFF
--- a/features/org.corpus-tools.atomic.feature.experimental/feature.xml
+++ b/features/org.corpus-tools.atomic.feature.experimental/feature.xml
@@ -48,6 +48,7 @@
       <import plugin="de.hu-berlin.german.korpling.annis.interfaces" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="com.google.guava" version="19.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.ui.ide"/>
    </requires>
 
    <plugin

--- a/features/org.corpus-tools.atomic.feature.experimental/feature.xml
+++ b/features/org.corpus-tools.atomic.feature.experimental/feature.xml
@@ -47,7 +47,10 @@
       <import plugin="org.corpus-tools.salt-api" version="3.3.1" match="greaterOrEqual"/>
       <import plugin="de.hu-berlin.german.korpling.annis.interfaces" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="com.google.guava" version="19.0.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.core.resources" version="3.11.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui" version="3.108.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui.workbench"/>
       <import plugin="org.eclipse.ui.ide"/>
    </requires>
 

--- a/plugins/org.corpus-tools.atomic.search/META-INF/MANIFEST.MF
+++ b/plugins/org.corpus-tools.atomic.search/META-INF/MANIFEST.MF
@@ -21,6 +21,8 @@ Require-Bundle: javax.inject,
  com.google.guava;bundle-version="19.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.core.resources,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.eclipse.ui,
+ org.eclipse.ui.part
 Bundle-ClassPath: .,
  swing2swt.jar

--- a/plugins/org.corpus-tools.atomic.search/META-INF/MANIFEST.MF
+++ b/plugins/org.corpus-tools.atomic.search/META-INF/MANIFEST.MF
@@ -18,11 +18,13 @@ Require-Bundle: javax.inject,
  org.corpus-tools.salt-api;bundle-version="3.3.1",
  org.eclipse.emf.common;bundle-version="2.12.0",
  de.hu-berlin.german.korpling.annis.interfaces;bundle-version="3.5.0",
- com.google.guava;bundle-version="19.0.0"
+ com.google.guava;bundle-version="19.0.0",
+ org.eclipse.core.resources;bundle-version="3.11.1",
+ org.eclipse.core.runtime;bundle-version="3.12.0",
+ org.eclipse.ui;bundle-version="3.108.1",
+ org.corpus_tools.atomic;bundle-version="0.3.0",
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.core.resources,
- org.eclipse.core.runtime,
- org.eclipse.ui,
- org.eclipse.ui.part
 Bundle-ClassPath: .,
  swing2swt.jar
+Import-Package: org.eclipse.ui.part

--- a/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/parts/ANNISSearch.java
+++ b/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/parts/ANNISSearch.java
@@ -148,18 +148,36 @@ public class ANNISSearch {
 						maxNumNodes = Math.max(maxNumNodes, m.getSaltIDs().size());
 					}
 					
+					// add columns for corpus and document name
+					TableColumn corpusColumn = new TableColumn(table, SWT.NULL);
+					corpusColumn.setText("corpus");
+					
+					TableColumn documentColumn = new TableColumn(table, SWT.NULL);
+					documentColumn.setText("document");
+					
 					for (int i = 1; i <= maxNumNodes; i++) {
 						TableColumn c = new TableColumn(table, SWT.NULL);
-						c.setText("" + i);
+						c.setText("node #" + i);
 					}
 					
 					int displayMatchCount = 0;
 					for (Match m : result.getMatches()) {
+
 						TableItem item = new TableItem(table, SWT.NULL);
+						
+						if(!m.getSaltIDs().isEmpty()) {
+							List<String> path = Splitter.on('/').omitEmptyStrings().trimResults().splitToList(
+									m.getSaltIDs().iterator().next().getPath());
+							item.setText(0, path.get(0)); // corpus
+							item.setText(1, path.get(path.size()-1)); // document
+						} else {
+							item.setText(0, "<unknown>");
+							item.setText(1, "<unknown>");
+						}
+							
 						int nodeIdx = 0;
 						for (URI u : m.getSaltIDs()) {
-							List<String> path = Splitter.on('/').trimResults().splitToList(u.getPath());
-							item.setText(nodeIdx, path.get(path.size()-1) + " (" + u.getFragment() + ")");
+							item.setText(2+nodeIdx, u.getFragment());
 							nodeIdx++;
 						}
 						displayMatchCount++;
@@ -168,7 +186,7 @@ public class ANNISSearch {
 						}
 					}
 
-					for (int i = 0; i < maxNumNodes; i++) {
+					for (int i = 0; i < table.getColumnCount(); i++) {
 						table.getColumn(i).pack();
 					}
 					long matchCount = result.getMatches().size();

--- a/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/parts/ANNISSearch.java
+++ b/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/parts/ANNISSearch.java
@@ -152,6 +152,8 @@ public class ANNISSearch {
 						TableColumn c = new TableColumn(table, SWT.NULL);
 						c.setText("" + i);
 					}
+					
+					int displayMatchCount = 0;
 					for (Match m : result.getMatches()) {
 						TableItem item = new TableItem(table, SWT.NULL);
 						int nodeIdx = 0;
@@ -160,13 +162,21 @@ public class ANNISSearch {
 							item.setText(nodeIdx, path.get(path.size()-1) + " (" + u.getFragment() + ")");
 							nodeIdx++;
 						}
+						displayMatchCount++;
+						if(displayMatchCount > 10000) {
+							break;
+						}
 					}
 
 					for (int i = 0; i < maxNumNodes; i++) {
 						table.getColumn(i).pack();
 					}
-					lblStatus.setText("Found " + result.getMatches().size() + " matches.");
-					
+					long matchCount = result.getMatches().size();
+					if(matchCount > 10000) {
+						lblStatus.setText("Found " + matchCount + " matches. (Only displaying first 10.000 matches)");
+					} else {
+						lblStatus.setText("Found " + matchCount + " matches.");
+					}
 				});
 				
 				return Status.OK_STATUS;

--- a/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/service/SearchService.java
+++ b/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/service/SearchService.java
@@ -44,6 +44,11 @@ public class SearchService {
 	}
 	
 	private void handleResource(IResource res, String projectName, IProgressMonitor monitor) throws CoreException {
+		
+		if(monitor.isCanceled()) {
+			return;
+		}
+		
 		if(res instanceof IFile) {
 			IFile file = (IFile) res;
 			if("salt".equals(file.getFileExtension()) && !"saltProject.salt".equals(file.getName())) {

--- a/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/service/SearchService.java
+++ b/plugins/org.corpus-tools.atomic.search/src/main/java/org/corpus_tools/search/service/SearchService.java
@@ -72,7 +72,6 @@ public class SearchService {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				
-				
 				// get all documents of workspace
 				IWorkspace workspace = ResourcesPlugin.getWorkspace();
 				IWorkspaceRoot root = workspace.getRoot();

--- a/target-definition/atomic-target-definition.target
+++ b/target-definition/atomic-target-definition.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="Atomic Target Platform" sequenceNumber="1488211932">
+<target name="Atomic Target Platform" sequenceNumber="1488298456">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.rcp.feature.group" version="4.6.2.v20161124-1400"/>
@@ -9,6 +9,7 @@
       <unit id="org.eclipse.help.feature.group" version="2.2.1.v20161124-1400"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20161122-1740"/>
       <unit id="org.eclipse.core.runtime" version="3.12.0.v20160606-1342"/>
+      <unit id="org.eclipse.ui.workbench" version="3.108.2.v20161025-2029"/>
       <unit id="org.eclipse.ui.navigator" version="3.6.101.v20161006-1120"/>
       <unit id="org.eclipse.ui.ide" version="3.12.2.v20161115-1450"/>
       <unit id="org.eclipse.ui.ide.application" version="1.1.101.v20160829-0827"/>
@@ -63,7 +64,7 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.e4.tools.model.spy" version="0.12.0.v20160114-2207"/>
+      <unit id="org.eclipse.e4.tools.spy" version="0.18.0.v20160520-1109"/>
       <repository location="http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest/"/>
     </location>
   </locations>

--- a/target-definition/atomic-target-definition.tpd
+++ b/target-definition/atomic-target-definition.tpd
@@ -8,6 +8,7 @@ location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.help.feature.group
 	org.eclipse.equinox.executable.feature.group
 	org.eclipse.core.runtime
+	org.eclipse.ui.workbench
 	org.eclipse.ui.navigator
 	org.eclipse.ui.ide
 	org.eclipse.ui.ide.application


### PR DESCRIPTION
Update the search UI to open a new editor using a context menu. Also use a more clear representation of the matches where the corpus and document name get their own column.