### PR TITLE
Remove eclipse collections

### DIFF
--- a/features/org.corpus-tools.atomic.feature.experimental/feature.xml
+++ b/features/org.corpus-tools.atomic.feature.experimental/feature.xml
@@ -28,16 +28,15 @@
       <import plugin="org.eclipse.nebula.widgets.nattable.core" version="1.4.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface.text" version="3.11.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.equinox.common"/>
-      <import plugin="org.eclipse.collections.eclipse-collections" version="8.1.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.editors"/>
       <import plugin="org.corpus-tools.salt-api" version="3.3.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.common" version="2.12.0" match="greaterOrEqual"/>
       <import plugin="org.apache.commons.io" version="2.4.0" match="greaterOrEqual"/>
+      <import plugin="com.google.guava" version="19.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.e4.ui.di"/>
       <import plugin="javax.inject"/>
       <import plugin="org.eclipse.osgi"/>
       <import plugin="org.eclipse.jface"/>
-      <import plugin="org.eclipse.e4.ui.model.workbench"/>
-      <import plugin="org.eclipse.e4.ui.di"/>
       <import plugin="org.eclipse.e4.ui.services"/>
       <import plugin="org.eclipse.e4.core.di.annotations"/>
       <import plugin="org.eclipse.e4.ui.workbench" version="1.4.0" match="greaterOrEqual"/>
@@ -46,12 +45,13 @@
       <import plugin="org.corpus-tools.graphannis-api" version="0.2.0" match="greaterOrEqual"/>
       <import plugin="org.corpus-tools.salt-api" version="3.3.1" match="greaterOrEqual"/>
       <import plugin="de.hu-berlin.german.korpling.annis.interfaces" version="3.5.0" match="greaterOrEqual"/>
-      <import plugin="com.google.guava" version="19.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.11.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.runtime" version="3.12.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui" version="3.108.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.workbench"/>
       <import plugin="org.eclipse.ui.ide"/>
+      <import plugin="json" version="20160810.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.e4.ui.model.workbench" version="1.2.0.v20160229-1459" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/plugins/org.corpus-tools.atomic.tokeneditor/META-INF/MANIFEST.MF
+++ b/plugins/org.corpus-tools.atomic.tokeneditor/META-INF/MANIFEST.MF
@@ -12,7 +12,6 @@ Require-Bundle: org.eclipse.ui,
  org.corpus-tools.salt-api;bundle-version="3.1.0",
  org.eclipse.nebula.widgets.nattable.core;bundle-version="1.4.0",
  org.eclipse.jface.text;bundle-version="3.11.1",
- org.eclipse.equinox.common,
- org.eclipse.collections.eclipse-collections;bundle-version="8.1.0"
+ org.eclipse.equinox.common
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.corpus-tools.atomic.tokeneditor/src/main/java/org/corpus_tools/atomic/tokeneditor/providers/TokenColumnHeaderDataProvider.java
+++ b/plugins/org.corpus-tools.atomic.tokeneditor/src/main/java/org/corpus_tools/atomic/tokeneditor/providers/TokenColumnHeaderDataProvider.java
@@ -1,8 +1,9 @@
 package org.corpus_tools.atomic.tokeneditor.providers;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.corpus_tools.salt.common.SDocumentGraph;
-import org.eclipse.collections.impl.list.Interval;
+import org.corpus_tools.salt.common.SToken;
 import org.eclipse.nebula.widgets.nattable.grid.data.DefaultColumnHeaderDataProvider;
 
 /**
@@ -21,7 +22,11 @@ public class TokenColumnHeaderDataProvider extends DefaultColumnHeaderDataProvid
 		 */
 		public TokenColumnHeaderDataProvider(SDocumentGraph graph) {
 			super(null);
-			this.tokenIndices = Interval.zeroTo(graph.getTokens().size() - 1);
+			List<SToken> tokens = graph.getTokens();
+			this.tokenIndices = new ArrayList<>(tokens.size());
+			for(int i=0; i < tokens.size(); i++) {
+				this.tokenIndices.add(i);
+			}
 		}
 
 		@Override

--- a/plugins/org.corpus-tools.atomic.visjs/.classpath
+++ b/plugins/org.corpus-tools.atomic.visjs/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="lib" path="swing2swt.jar"/>
+	<classpathentry kind="src" path="src/main/java/"/>
+	<classpathentry exported="true" kind="lib" path="swing2swt.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.corpus-tools.atomic.visjs/.project
+++ b/plugins/org.corpus-tools.atomic.visjs/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/target-definition/atomic-target-definition.target
+++ b/target-definition/atomic-target-definition.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="Atomic Target Platform" sequenceNumber="1488298456">
+<target name="Atomic Target Platform" sequenceNumber="1488465423">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.rcp.feature.group" version="4.6.2.v20161124-1400"/>
@@ -49,8 +49,7 @@
       <unit id="org.eclipse.aether.transport.http" version="1.0.2.v20150114"/>
       <unit id="org.eclipse.aether.util" version="1.0.2.v20150114"/>
       <unit id="com.github.hazendaz.javabean-tester" version="1.4.0"/>
-      <unit id="org.eclipse.collections.eclipse-collections" version="8.1.0.20170227104546"/>
-      <unit id="org.corpus-tools.graphannis-api" version="0.2.0.20170227104542"/>
+      <unit id="org.corpus-tools.graphannis-api" version="0.2.0.20170302135044"/>
       <repository location="http://corpus-tools.org/p2/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/target-definition/atomic-target-definition.tpd
+++ b/target-definition/atomic-target-definition.tpd
@@ -48,7 +48,6 @@ location "http://corpus-tools.org/p2/" {
 	org.eclipse.aether.transport.http
 	org.eclipse.aether.util
 	com.github.hazendaz.javabean-tester
-	org.eclipse.collections.eclipse-collections
 	
 	org.corpus-tools.graphannis-api
 }


### PR DESCRIPTION
The current eclipse collections are a SNAPSHOT dependency that causes problems with the target platform definition on a regular basis. Its easier to use a for loop at the one place where this library was used instead of hazzling with the dependencies.